### PR TITLE
Add fzf integration (bash, zsh, fish)

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -62,6 +62,9 @@ for file in ~/.dotfiles/fish/tabcomplete*
     source $file
 end
 
+# Source fzf integration (no-op if fzf not installed)
+source ~/.dotfiles/fish/fzf.fish
+
 # Source fish prompt configuration
 source ~/.dotfiles/fish/prompt.fish
 

--- a/fish/fzf.fish
+++ b/fish/fzf.fish
@@ -1,0 +1,39 @@
+# fzf integration for fish
+# Key bindings require either fzf.fish (fisher install PatrickF1/fzf.fish)
+# or the minimal Ctrl+R binding defined below.
+# No-op if fzf is not installed.
+
+if not type -q fzf
+    exit
+end
+
+set -gx FZF_DEFAULT_OPTS '--height 40% --border --inline-info'
+
+# If the fzf.fish plugin is installed its bindings take precedence; skip the
+# minimal fallback so we don't double-bind Ctrl+R.
+if functions -q _fzf_search_history
+    exit
+end
+
+# Minimal Ctrl+R: fuzzy history search
+function _fzf_history --description "Fuzzy history search"
+    set -l query (commandline)
+    set -l cmd (builtin history | fzf --tac --no-sort --query=$query --height 40% --border --prompt="history: ")
+    if test -n "$cmd"
+        commandline -- $cmd
+    end
+    commandline -f repaint
+end
+
+bind \cr _fzf_history
+
+# gcof: interactive git branch checkout using fzf
+function gcof --description "Fuzzy git branch checkout"
+    set -l branch (git branch --all \
+        | grep -v HEAD \
+        | string trim \
+        | string replace -r '^remotes/origin/' '' \
+        | sort -u \
+        | fzf --height 40% --border --prompt="checkout: ")
+    test -n "$branch"; and git checkout $branch
+end

--- a/fish/fzf.fish
+++ b/fish/fzf.fish
@@ -1,7 +1,23 @@
 # fzf integration for fish
 # Key bindings require either fzf.fish (fisher install PatrickF1/fzf.fish)
 # or the minimal Ctrl+R binding defined below.
-# No-op if fzf is not installed.
+# Key bindings are a no-op when fzf is not installed; gcof is always defined
+# and reports a clear error when fzf is missing (matching bash/zsh).
+
+# gcof: interactive git branch checkout using fzf
+function gcof --description "Fuzzy git branch checkout"
+    if not type -q fzf
+        echo "gcof: fzf not installed" >&2
+        return 1
+    end
+    set -l branch (git branch --all \
+        | grep -v HEAD \
+        | string replace -r '^[*+]?\s*' '' \
+        | string replace -r '^remotes/origin/' '' \
+        | sort -u \
+        | fzf --height 40% --border --prompt="checkout: ")
+    test -n "$branch"; and git checkout $branch
+end
 
 if not type -q fzf
     exit
@@ -26,14 +42,3 @@ function _fzf_history --description "Fuzzy history search"
 end
 
 bind \cr _fzf_history
-
-# gcof: interactive git branch checkout using fzf
-function gcof --description "Fuzzy git branch checkout"
-    set -l branch (git branch --all \
-        | grep -v HEAD \
-        | string trim \
-        | string replace -r '^remotes/origin/' '' \
-        | sort -u \
-        | fzf --height 40% --border --prompt="checkout: ")
-    test -n "$branch"; and git checkout $branch
-end

--- a/shared/fzf
+++ b/shared/fzf
@@ -6,27 +6,49 @@ if command -v fzf &>/dev/null; then
     export FZF_DEFAULT_OPTS='--height 40% --border --inline-info'
 
     if [[ -n "$BASH_VERSION" ]]; then
-        if [[ -f ~/.fzf.bash ]]; then
-            source ~/.fzf.bash
-        elif [[ -f /opt/homebrew/opt/fzf/shell/key-bindings.bash ]]; then
-            source /opt/homebrew/opt/fzf/shell/key-bindings.bash
-            source /opt/homebrew/opt/fzf/shell/completion.bash 2>/dev/null
-        elif [[ -f /usr/share/doc/fzf/examples/key-bindings.bash ]]; then
-            source /usr/share/doc/fzf/examples/key-bindings.bash
-            source /usr/share/doc/fzf/examples/completion.bash 2>/dev/null
-        fi
+        # Try each candidate until fzf's Ctrl+R widget is actually loaded.
+        # A candidate (e.g. a stale ~/.fzf.bash) that fails to define the
+        # widget must not stop us from trying the next one, so we check that
+        # __fzf_history__ exists rather than just stopping on first source.
+        for _fzf_src in \
+            ~/.fzf.bash \
+            /opt/homebrew/opt/fzf/shell/key-bindings.bash \
+            /usr/share/doc/fzf/examples/key-bindings.bash \
+            /usr/share/fzf/key-bindings.bash \
+            /usr/share/fzf/shell/key-bindings.bash; do
+            declare -F __fzf_history__ &>/dev/null && break
+            [[ -r "$_fzf_src" ]] && source "$_fzf_src" 2>/dev/null
+        done
+
+        # Completion is optional and loaded separately so a failure here can't
+        # prevent the key bindings above from taking effect.
+        for _fzf_src in \
+            /opt/homebrew/opt/fzf/shell/completion.bash \
+            /usr/share/doc/fzf/examples/completion.bash \
+            /usr/share/fzf/completion.bash; do
+            [[ -r "$_fzf_src" ]] && source "$_fzf_src" 2>/dev/null && break
+        done
+        unset _fzf_src
     fi
 
     if [[ -n "$ZSH_VERSION" ]]; then
-        if [[ -f ~/.fzf.zsh ]]; then
-            source ~/.fzf.zsh
-        elif [[ -f /opt/homebrew/opt/fzf/shell/key-bindings.zsh ]]; then
-            source /opt/homebrew/opt/fzf/shell/key-bindings.zsh
-            source /opt/homebrew/opt/fzf/shell/completion.zsh 2>/dev/null
-        elif [[ -f /usr/share/doc/fzf/examples/key-bindings.zsh ]]; then
-            source /usr/share/doc/fzf/examples/key-bindings.zsh
-            source /usr/share/doc/fzf/examples/completion.zsh 2>/dev/null
-        fi
+        for _fzf_src in \
+            ~/.fzf.zsh \
+            /opt/homebrew/opt/fzf/shell/key-bindings.zsh \
+            /usr/share/doc/fzf/examples/key-bindings.zsh \
+            /usr/share/fzf/key-bindings.zsh \
+            /usr/share/fzf/shell/key-bindings.zsh; do
+            (( $+functions[fzf-history-widget] )) && break
+            [[ -r "$_fzf_src" ]] && source "$_fzf_src" 2>/dev/null
+        done
+
+        for _fzf_src in \
+            /opt/homebrew/opt/fzf/shell/completion.zsh \
+            /usr/share/doc/fzf/examples/completion.zsh \
+            /usr/share/fzf/completion.zsh; do
+            [[ -r "$_fzf_src" ]] && source "$_fzf_src" 2>/dev/null && break
+        done
+        unset _fzf_src
     fi
 fi
 

--- a/shared/fzf
+++ b/shared/fzf
@@ -61,7 +61,7 @@ gcof() {
     local branch
     branch=$(git branch --all \
         | grep -v HEAD \
-        | sed 's/^[[:space:]]*//' \
+        | sed 's/^[*+[:space:]]*//' \
         | sed 's|^remotes/origin/||' \
         | sort -u \
         | fzf --height 40% --border --prompt="checkout: ")

--- a/shared/fzf
+++ b/shared/fzf
@@ -1,0 +1,47 @@
+# fzf integration for bash and zsh
+# Enables fuzzy history search (Ctrl+R), file search (Ctrl+T), and cd (Alt+C)
+# No-op if fzf is not installed.
+
+if command -v fzf &>/dev/null; then
+    export FZF_DEFAULT_OPTS='--height 40% --border --inline-info'
+
+    if [[ -n "$BASH_VERSION" ]]; then
+        if [[ -f ~/.fzf.bash ]]; then
+            source ~/.fzf.bash
+        elif [[ -f /opt/homebrew/opt/fzf/shell/key-bindings.bash ]]; then
+            source /opt/homebrew/opt/fzf/shell/key-bindings.bash
+            source /opt/homebrew/opt/fzf/shell/completion.bash 2>/dev/null
+        elif [[ -f /usr/share/doc/fzf/examples/key-bindings.bash ]]; then
+            source /usr/share/doc/fzf/examples/key-bindings.bash
+            source /usr/share/doc/fzf/examples/completion.bash 2>/dev/null
+        fi
+    fi
+
+    if [[ -n "$ZSH_VERSION" ]]; then
+        if [[ -f ~/.fzf.zsh ]]; then
+            source ~/.fzf.zsh
+        elif [[ -f /opt/homebrew/opt/fzf/shell/key-bindings.zsh ]]; then
+            source /opt/homebrew/opt/fzf/shell/key-bindings.zsh
+            source /opt/homebrew/opt/fzf/shell/completion.zsh 2>/dev/null
+        elif [[ -f /usr/share/doc/fzf/examples/key-bindings.zsh ]]; then
+            source /usr/share/doc/fzf/examples/key-bindings.zsh
+            source /usr/share/doc/fzf/examples/completion.zsh 2>/dev/null
+        fi
+    fi
+fi
+
+# Interactive git branch checkout using fzf; falls back to plain git checkout
+gcof() {
+    if ! command -v fzf &>/dev/null; then
+        echo "gcof: fzf not installed" >&2
+        return 1
+    fi
+    local branch
+    branch=$(git branch --all \
+        | grep -v HEAD \
+        | sed 's/^[[:space:]]*//' \
+        | sed 's|^remotes/origin/||' \
+        | sort -u \
+        | fzf --height 40% --border --prompt="checkout: ")
+    [[ -n "$branch" ]] && git checkout "$branch"
+}


### PR DESCRIPTION
## Summary

- Adds `shared/fzf` — sources fzf key bindings (Ctrl+R history, Ctrl+T file, Alt+C dir) from common install locations (Homebrew, apt, `~/.fzf.*`). No-op when fzf is not installed.
- Adds `fish/fzf.fish` — same for fish; uses the `fzf.fish` plugin bindings when installed (via `fisher install PatrickF1/fzf.fish`), otherwise wires a minimal Ctrl+R fallback.
- Sets `FZF_DEFAULT_OPTS='--height 40% --border --inline-info'` across all shells.
- Adds `gcof` function (bash/zsh/fish) — interactive git branch checkout via fzf; exits with a clear error message when fzf is not installed.

## Install fzf

```
# macOS
brew install fzf && $(brew --prefix)/opt/fzf/install

# Ubuntu/Debian
sudo apt install fzf

# From source
git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf && ~/.fzf/install
```

## Test plan

- [ ] bash: `Ctrl+R` opens fuzzy history search
- [ ] zsh: `Ctrl+R` opens fuzzy history search
- [ ] fish: `Ctrl+R` opens fuzzy history search
- [ ] `gcof` with fzf installed shows branch picker
- [ ] `gcof` without fzf installed prints a clear error and returns non-zero
- [ ] Sourcing works cleanly when fzf is not installed (no errors)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwFoFEtyRpd76kij16Bz8C)_