### PR TITLE
Add delta as git pager with less -S fallback

### DIFF
--- a/bin/git-delta-filter
+++ b/bin/git-delta-filter
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Interactive diff filter for git add -p: uses delta when available, falls back to cat
+if command -v delta &>/dev/null; then
+    exec delta --color-only "$@"
+else
+    exec cat
+fi

--- a/bin/git-pager
+++ b/bin/git-pager
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Git pager: uses delta when available, falls back to less -S
+if command -v delta &>/dev/null; then
+    exec delta "$@"
+else
+    exec less -S "$@"
+fi

--- a/git/gitconfig.template
+++ b/git/gitconfig.template
@@ -25,7 +25,7 @@
   excludesfile = ~/.gitignore
   editor = vim
   autocrlf = input
-  pager = less -S
+  pager = git-pager
 [apply]
   whitespace = nowarn
 [format]
@@ -35,5 +35,11 @@
 [push]
   default = tracking
   recurseSubmodules = check
+[interactive]
+  diffFilter = git-delta-filter
+[delta]
+  navigate = true
+  line-numbers = true
+  side-by-side = false
 [pull]
 	rebase = false


### PR DESCRIPTION
## Summary

- Adds `bin/git-pager` — uses `delta` when installed, falls back to `less -S`.
- Adds `bin/git-delta-filter` — used for `git add -p`; pipes through `delta --color-only` when installed, falls back to `cat`.
- Updates `gitconfig.template` to use both scripts and includes delta config (`navigate`, `line-numbers`).

Both scripts are in `~/.dotfiles/bin` which is already on `$PATH`, so they work in all shells without any per-shell wiring.

## Install delta

```
# macOS
brew install git-delta

# Ubuntu/Debian
sudo apt install git-delta   # or download from GitHub releases
```

## Test plan

- [ ] `git diff` uses delta for output when delta is installed
- [ ] `git log` uses delta pager when delta is installed
- [ ] `git add -p` shows syntax-highlighted hunks when delta is installed
- [ ] All of the above fall back gracefully when delta is **not** installed
- [ ] `git-pager` and `git-delta-filter` are executable after `install.sh`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwFoFEtyRpd76kij16Bz8C)_