### PR TITLE
Add rg/fd as grep/find replacements with fallbacks

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -21,6 +21,9 @@ source ~/.dotfiles/fish/aliases
 # Source fish-specific functions
 source ~/.dotfiles/fish/functions.fish
 
+# Source modern CLI tool aliases (rg, fd) with fallbacks
+source ~/.dotfiles/fish/modern_cli.fish
+
 # Load NVM if available (Fish shell approach)
 if test -s ~/.nvm/nvm.sh
     # For Fish, we need to use bass to run nvm commands or use fisher nvm plugin

--- a/fish/modern_cli.fish
+++ b/fish/modern_cli.fish
@@ -1,0 +1,12 @@
+# Modern CLI tool aliases for fish
+# Each alias only applies when the replacement tool is installed.
+
+# ripgrep: faster grep with smarter defaults (respects .gitignore, etc.)
+if type -q rg
+    alias grep='rg'
+end
+
+# fd: faster, friendlier find
+if type -q fd
+    alias find='fd'
+end

--- a/shared/modern_cli
+++ b/shared/modern_cli
@@ -1,0 +1,12 @@
+# Modern CLI tool aliases for bash and zsh
+# Each alias only applies when the replacement tool is installed.
+
+# ripgrep: faster grep with smarter defaults (respects .gitignore, etc.)
+if command -v rg &>/dev/null; then
+    alias grep='rg'
+fi
+
+# fd: faster, friendlier find
+if command -v fd &>/dev/null; then
+    alias find='fd'
+fi


### PR DESCRIPTION
## Summary

- Adds `shared/modern_cli` — sourced automatically by bash and zsh via the existing `shared/*` loop. Aliases `grep → rg` and `find → fd` only when the tools are present.
- Adds `fish/modern_cli.fish` — same aliases for fish using `type -q` guards; sourced from `config.fish`.

When neither tool is installed nothing changes — the original `grep` and `find` commands are used as-is.

## Install

```
# macOS
brew install ripgrep fd

# Ubuntu/Debian
sudo apt install ripgrep fd-find
# Note: on Debian/Ubuntu fd is installed as `fdfind`; alias manually if needed:
# alias fd=fdfind
```

## Test plan

- [ ] bash/zsh: `grep foo` routes through `rg` when ripgrep is installed
- [ ] bash/zsh: `find . -name "*.js"` routes through `fd` when fd is installed
- [ ] fish: same for both
- [ ] bash/zsh/fish: original `grep`/`find` used unchanged when tools are absent
- [ ] Sourcing produces no errors on a machine without rg or fd

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwFoFEtyRpd76kij16Bz8C)_